### PR TITLE
Add universal badge processing skeleton

### DIFF
--- a/aphrodite-v2/api/app/services/badge_processing/__init__.py
+++ b/aphrodite-v2/api/app/services/badge_processing/__init__.py
@@ -1,0 +1,19 @@
+from .pipeline import UniversalBadgeProcessor
+from .types import (
+    UniversalBadgeRequest,
+    SingleBadgeRequest,
+    BulkBadgeRequest,
+    ProcessingResult,
+    ProcessingMode,
+    PosterResult,
+)
+
+__all__ = [
+    "UniversalBadgeProcessor",
+    "UniversalBadgeRequest",
+    "SingleBadgeRequest",
+    "BulkBadgeRequest",
+    "ProcessingResult",
+    "ProcessingMode",
+    "PosterResult",
+]

--- a/aphrodite-v2/api/app/services/badge_processing/pipeline.py
+++ b/aphrodite-v2/api/app/services/badge_processing/pipeline.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import time
+from typing import List
+
+from aphrodite_logging import get_logger
+
+from .types import (
+    UniversalBadgeRequest,
+    SingleBadgeRequest,
+    BulkBadgeRequest,
+    ProcessingResult,
+    PosterResult,
+    ProcessingMode,
+)
+
+
+class UniversalBadgeProcessor:
+    """Universal entry point for badge processing."""
+
+    def __init__(self):
+        self.logger = get_logger("aphrodite.badge.pipeline")
+
+    async def process_request(self, request: UniversalBadgeRequest) -> ProcessingResult:
+        start = time.perf_counter()
+
+        if request.processing_mode == ProcessingMode.AUTO:
+            mode = await self.auto_select_mode(request)
+        else:
+            mode = request.processing_mode
+
+        if mode == ProcessingMode.IMMEDIATE and request.single_request:
+            result = await self.process_single(request.single_request)
+        elif mode == ProcessingMode.QUEUED and request.bulk_request:
+            result = await self.process_bulk(request.bulk_request)
+        else:
+            result = ProcessingResult(success=False, results=[], error="Invalid request")
+
+        result.processing_time = time.perf_counter() - start
+        return result
+
+    async def process_single(self, request: SingleBadgeRequest) -> ProcessingResult:
+        self.logger.debug(f"Processing single poster: {request.poster_path}")
+        # Placeholder image processing logic
+        result = PosterResult(
+            source_path=request.poster_path,
+            output_path=request.output_path or request.poster_path,
+            applied_badges=request.badge_types,
+            success=True,
+        )
+        return ProcessingResult(success=True, results=[result])
+
+    async def process_bulk(self, request: BulkBadgeRequest) -> ProcessingResult:
+        self.logger.debug(f"Processing bulk posters: {len(request.poster_paths)}")
+        results: List[PosterResult] = []
+        for path in request.poster_paths:
+            single_result = await self.process_single(
+                SingleBadgeRequest(
+                    poster_path=path,
+                    badge_types=request.badge_types,
+                    use_demo_data=request.use_demo_data,
+                    output_path=None,
+                )
+            )
+            results.extend(single_result.results)
+        return ProcessingResult(success=True, results=results)
+
+    async def auto_select_mode(self, request: UniversalBadgeRequest) -> ProcessingMode:
+        if request.bulk_request and len(request.bulk_request.poster_paths) > 5:
+            return ProcessingMode.QUEUED
+        return ProcessingMode.IMMEDIATE

--- a/aphrodite-v2/api/app/services/badge_processing/types.py
+++ b/aphrodite-v2/api/app/services/badge_processing/types.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import List, Optional
+from pydantic import BaseModel
+
+class ProcessingMode(str, Enum):
+    IMMEDIATE = "immediate"
+    QUEUED = "queued"
+    AUTO = "auto"
+
+class SingleBadgeRequest(BaseModel):
+    poster_path: str
+    badge_types: List[str]
+    use_demo_data: bool = False
+    output_path: Optional[str] = None
+
+class BulkBadgeRequest(BaseModel):
+    poster_paths: List[str]
+    badge_types: List[str]
+    use_demo_data: bool = False
+    output_directory: Optional[str] = None
+    batch_size: int = 10
+
+class UniversalBadgeRequest(BaseModel):
+    single_request: Optional[SingleBadgeRequest] = None
+    bulk_request: Optional[BulkBadgeRequest] = None
+    processing_mode: ProcessingMode = ProcessingMode.AUTO
+
+class PosterResult(BaseModel):
+    source_path: str
+    output_path: Optional[str] = None
+    applied_badges: List[str] = []
+    success: bool = True
+    error: Optional[str] = None
+
+class ProcessingResult(BaseModel):
+    success: bool
+    results: List[PosterResult]
+    job_id: Optional[str] = None
+    processing_time: float = 0.0
+    error: Optional[str] = None

--- a/tests/test_badge_pipeline.py
+++ b/tests/test_badge_pipeline.py
@@ -1,0 +1,61 @@
+import unittest
+import sys
+import importlib.util
+from pathlib import Path
+
+# Dynamically load badge processing modules without requiring full service dependencies
+parent_dir = Path(__file__).parent.parent
+sys.path.append(str(parent_dir / "aphrodite-v2"))
+
+badge_dir = parent_dir / "aphrodite-v2" / "api" / "app" / "services" / "badge_processing"
+
+# Load types module
+types_spec = importlib.util.spec_from_file_location("badge_processing.types", badge_dir / "types.py")
+types_module = importlib.util.module_from_spec(types_spec)
+sys.modules["badge_processing.types"] = types_module
+types_spec.loader.exec_module(types_module)
+
+# Load pipeline module
+pipeline_spec = importlib.util.spec_from_file_location(
+    "badge_processing.pipeline", badge_dir / "pipeline.py", submodule_search_locations=[str(badge_dir)]
+)
+pipeline_module = importlib.util.module_from_spec(pipeline_spec)
+sys.modules["badge_processing.pipeline"] = pipeline_module
+pipeline_spec.loader.exec_module(pipeline_module)
+
+UniversalBadgeProcessor = pipeline_module.UniversalBadgeProcessor
+UniversalBadgeRequest = pipeline_module.UniversalBadgeRequest
+SingleBadgeRequest = pipeline_module.SingleBadgeRequest
+BulkBadgeRequest = pipeline_module.BulkBadgeRequest
+ProcessingMode = pipeline_module.ProcessingMode
+
+class TestBadgePipeline(unittest.IsolatedAsyncioTestCase):
+    async def test_single_processing(self):
+        processor = UniversalBadgeProcessor()
+        request = UniversalBadgeRequest(
+            single_request=SingleBadgeRequest(
+                poster_path="/tmp/poster.jpg",
+                badge_types=["audio"],
+            ),
+            processing_mode=ProcessingMode.IMMEDIATE,
+        )
+        result = await processor.process_request(request)
+        self.assertTrue(result.success)
+        self.assertEqual(len(result.results), 1)
+        self.assertEqual(result.results[0].applied_badges, ["audio"])
+
+    async def test_bulk_processing_auto_mode(self):
+        processor = UniversalBadgeProcessor()
+        request = UniversalBadgeRequest(
+            bulk_request=BulkBadgeRequest(
+                poster_paths=[f"poster_{i}.jpg" for i in range(6)],
+                badge_types=["audio", "resolution"],
+            ),
+            processing_mode=ProcessingMode.AUTO,
+        )
+        result = await processor.process_request(request)
+        self.assertTrue(result.success)
+        self.assertEqual(len(result.results), 6)
+        for r in result.results:
+            self.assertIn("audio", r.applied_badges)
+            self.assertIn("resolution", r.applied_badges)


### PR DESCRIPTION
## Summary
- add initial badge processing service modules
- implement pipeline and request/result models
- add tests for badge pipeline

## Testing
- `python tests/run_tests.py` *(fails: test_cli_backup, test_end_to_end_scenario)*